### PR TITLE
fix: rename enum values to lowercase

### DIFF
--- a/src/main/java/io/camunda/connector/awslambda/model/OperationType.java
+++ b/src/main/java/io/camunda/connector/awslambda/model/OperationType.java
@@ -7,6 +7,6 @@
 package io.camunda.connector.awslambda.model;
 
 public enum OperationType {
-  SYNC,
-  ASYNC
+  sync,
+  async
 }


### PR DESCRIPTION
## Description

It appears that Gson has issues with upper/lower cases in enum deserialization.

For some reason, it only fails in Docker connectors bundle, while in SaaS and local runtime works just fine.

This fix is a quick fix to unblock usage of the connector.

## Related issues

- #71

## Testing done:

- Local Docker Bundle
- Local runtime

